### PR TITLE
Fix CWorld::RemoveFallenPeds

### DIFF
--- a/source/game_sa/CWorld.cpp
+++ b/source/game_sa/CWorld.cpp
@@ -264,7 +264,6 @@ void CWorld::RemoveFallenPeds() {
             if (pathNodeAddress.m_wAreaId != -1)
             {
                 CVector pathNodePos = ThePaths.GetPathNode(pathNodeAddress)->GetNodeCoors();
-                pathNodePos *= 0.125f;
                 pathNodePos.z += 2.0f;
                 pPed->Teleport(pathNodePos, false); 
             }


### PR DESCRIPTION
As mentioned in the previous PR, the `* 0,125` that got added in unnecessary, as the vector that `GetNodeCoors` returns is already decompressed:
![image](https://user-images.githubusercontent.com/12902714/99188901-b01c8400-275e-11eb-9f73-4cfe3f99de49.png)
